### PR TITLE
composer_install_fails-2905060-4.patch

### DIFF
--- a/sendinblue.info.yml
+++ b/sendinblue.info.yml
@@ -5,7 +5,7 @@ package : SendinBlue
 
 # core : 8.x
 dependencies:
-  - libraries (>=2)
+  - libraries
 
 libraries:
   - sendinblue/sendinblue.admin-setting


### PR DESCRIPTION
2905060 - Composer install fails, we have to use the 3.x-dev version of libraries.

(>=2) was deprecated, we used it in Drupal 7 version.